### PR TITLE
Fixed eyedropper image bug

### DIFF
--- a/app/color_picker.js
+++ b/app/color_picker.js
@@ -88,9 +88,13 @@ function mouseMoveListener(e) {
         eyeDropperImage.style.zIndex = "9999";
         document.body.appendChild(eyeDropperImage);
     }
+    
 
+    eyeDropperImage.style.visibility = "visible";
+    eyeDropperImage.style.display = "inline-block";
     eyeDropperImage.style.top = e.pageY - 25 +"px";
     eyeDropperImage.style.left = e.pageX + "px";
+
 
     colorText.style.visibility = "visible";
     colorText.style.top = e.pageY - 55 + "px";


### PR DESCRIPTION
The icon didn't show because the img tag it had the visibility set to hidden and the display set to none. The icon has been set in the mouseMoveListener to have the visibility set to visible and the dislay set to inline-block. 